### PR TITLE
Ravenjs >= 2.0 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 language: python
+
+dist: precise
+
 python:
   - "2.6"
   - "2.7"

--- a/cyclops/handlers/router.py
+++ b/cyclops/handlers/router.py
@@ -88,10 +88,8 @@ class BaseRouterHandler(BaseHandler):
                 self._404()
                 is_accessible = False
 
-            # get public key
-            sentry_key = self.get_argument('sentry_key').strip()
-
             # check public key
+            sentry_key = self.get_argument('sentry_key').strip()
             if sentry_key not in self.application.project_keys[project_id]["public_key"]:
                 self._403()
                 is_accessible = False

--- a/cyclops/handlers/router.py
+++ b/cyclops/handlers/router.py
@@ -163,7 +163,15 @@ class BaseRouterHandler(BaseHandler):
                 self.finish()
                 return
 
-        count = self.validate_cache(url)
+        try:
+            payload = loads(self.request.body)
+        except ValueError:
+            payload = loads(decompress(b64decode(self.request.body)))
+
+        message_key = hash_for_grouping(payload)
+
+        cache_key = "%s:%s" % (project_id, message_key)
+        count = self.validate_cache(cache_key)
         if count > self.application.config.MAX_CACHE_USES:
             return
 

--- a/cyclops/handlers/router.py
+++ b/cyclops/handlers/router.py
@@ -124,6 +124,7 @@ class BaseRouterHandler(BaseHandler):
         keys = self.application.project_keys.get(project_id)
         if keys is None:
             return False
+
         return public_key in keys['public_key'] and secret_key in keys['secret_key']
 
     def frontend_request(self, project_id):
@@ -132,6 +133,15 @@ class BaseRouterHandler(BaseHandler):
                 self._404()
                 return
 
+        # CORS headers
+        origin = self.request.headers.get('Origin')
+        if origin:
+            self.set_header("Access-Control-Allow-Headers", "X-Sentry-Auth, X-Requested-With, Origin, Accept, Content-Type, Authentication")
+            self.set_header("Access-Control-Allow-Methods", "GET, POST, HEAD, OPTIONS")
+            self.set_header("Access-Control-Allow-Origin", origin)
+            self.set_header("Access-Control-Expose-Headers", "X-Sentry-Error, Retry-After")
+
+        # Check public key
         project_id = int(project_id)
         sentry_key = self.get_argument('sentry_key')
         if self.application.config.RESTRICT_API_ACCESS:

--- a/cyclops/handlers/router.py
+++ b/cyclops/handlers/router.py
@@ -171,7 +171,13 @@ class RouterHandler(BaseRouterHandler):
 
     @tornado.web.asynchronous
     def post(self, project_id=None):
-        self.backend_request(project_id)
+        auth = self.request.headers.get('X-Sentry-Auth')
+        if auth:
+            # backend client uses private DSN and sends key and sectet in X-Sentry-Auth header
+            self.backend_request(project_id)
+        else:
+            # browser based client uses public DSN and sends only key in QUERY_STRING
+            self.frontend_request(project_id)
 
 class OldRouterHandler(BaseRouterHandler):
     @tornado.web.asynchronous

--- a/cyclops/handlers/router.py
+++ b/cyclops/handlers/router.py
@@ -23,6 +23,34 @@ class BaseRouterHandler(BaseHandler):
         self.set_status(404)
         self.finish()
 
+    def _403(self):
+        self.set_status(403)
+        self.write("INVALID KEY")
+        self.finish()
+
+    def send_ignored_response(self):
+        self.set_header("X-CYCLOPS-STATUS", "IGNORED")
+        self.application.ignored_items += 1
+        self.write("IGNORED")
+        self.finish()
+
+    def send_processed_response(self):
+        self.set_header("X-CYCLOPS-STATUS", "PROCESSED")
+        self.application.processed_items += 1
+        self.set_status(200)
+        self.write("OK")
+        self.finish()
+
+    def validate_percentage_ignore(self, project_id):
+        is_ignored = False
+        if project_id in self.application.config.IGNORE_PERCENTAGE:
+            value = randint(1, 100)
+            if value < int(self.application.config.IGNORE_PERCENTAGE[project_id]):
+                self.send_ignored_response()
+                is_ignored = True
+
+        return is_ignored
+
     def get_cache_key(self, project_id, request_body):
         try:
             payload = loads(request_body)
@@ -34,7 +62,7 @@ class BaseRouterHandler(BaseHandler):
         return cache_key
 
     def validate_cache(self, project_id, request_body):
-        count = 0
+        is_ignored = False
 
         if self.application.config.URL_CACHE_EXPIRATION > 0:
             cache_key = self.get_cache_key(project_id, request_body)
@@ -46,18 +74,31 @@ class BaseRouterHandler(BaseHandler):
             self.set_header("X-CYCLOPS-CACHE-COUNT", str(count))
 
             if count > self.application.config.MAX_CACHE_USES:
-                self.set_header("X-CYCLOPS-STATUS", "IGNORED")
-                self.application.ignored_items += 1
-                self.write("IGNORED")
-                self.finish()
-            else:
-                self.set_header("X-CYCLOPS-STATUS", "PROCESSED")
+                self.send_ignored_response()
+                is_ignored = True
 
-        return count
+        return is_ignored
+
+    def validate_project_by_public_dsn(self, project_id):
+        is_accessible = True
+
+        if self.application.config.RESTRICT_API_ACCESS:
+            # check project in restrict api list
+            if int(project_id) not in self.application.project_keys:
+                self._404()
+                is_accessible = False
+
+            # get public key
+            sentry_key = self.get_argument('sentry_key').strip()
+
+            # check public key
+            if sentry_key not in self.application.project_keys[project_id]["public_key"]:
+                self._403()
+                is_accessible = False
+
+        return is_accessible
 
     def process_request(self, project_id, url):
-        self.application.processed_items += 1
-
         headers = {}
         body = self.request.body
         for k, v in sorted(self.request.headers.get_all()):
@@ -72,11 +113,7 @@ class BaseRouterHandler(BaseHandler):
         )
 
         self.application.storage.put(project_id, message)
-        #self.application.items_to_process[project_id].put(msgpack.packb(message))
-
-        self.set_status(200)
-        self.write("OK")
-        self.finish()
+        self.send_processed_response()
 
     def handle_backend_post_request(self, project_id=None):
         # check if auth token passed
@@ -113,17 +150,14 @@ class BaseRouterHandler(BaseHandler):
                 self._404()
                 return
 
-        # generate sentry url
-        base_url = self.application.config.SENTRY_BASE_URL.replace('http://', '').replace('https://', '')
-        base_url = "%s://%s:%s@%s" % (self.request.protocol, sentry_key, sentry_secret, base_url)
-        url = "%s%s?%s" % (base_url, self.request.path, self.request.query)
-
         # check cache usage
-        count = self.validate_cache(project_id, self.request.body)
-        if count > self.application.config.MAX_CACHE_USES:
+        if self.validate_cache(project_id, self.request.body):
             return
 
         # handle request
+        base_url = self.application.config.SENTRY_BASE_URL.replace('http://', '').replace('https://', '')
+        base_url = "%s://%s:%s@%s" % (self.request.protocol, sentry_key, sentry_secret, base_url)
+        url = "%s%s?%s" % (base_url, self.request.path, self.request.query)
         self.process_request(project_id, url)
 
     def get_project_id(self, public_key, secret_key):
@@ -148,81 +182,39 @@ class BaseRouterHandler(BaseHandler):
             self.set_header("Access-Control-Allow-Origin", origin)
             self.set_header("Access-Control-Expose-Headers", "X-Sentry-Error, Retry-After")
 
-        # check project in restrict api list
-        if self.application.config.RESTRICT_API_ACCESS:
-            if int(project_id) not in self.application.project_keys:
-                self._404()
-                return
-
-        # check public key
+        # check project accessibility
         project_id = int(project_id)
-        sentry_key = self.get_argument('sentry_key')
-        if self.application.config.RESTRICT_API_ACCESS:
-            if not sentry_key.strip() in self.application.project_keys[project_id]["public_key"]:
-                self.set_status(403)
-                self.write("INVALID KEY")
-                self.finish()
-                return
-
-        # generate sentry url
-        url = "%s%s?%s" % (self.application.config.SENTRY_BASE_URL, self.request.path, self.request.query)
+        if not self.validate_project_by_public_dsn(project_id):
+            return
 
         # ignore by percentage
-        if project_id in self.application.config.IGNORE_PERCENTAGE:
-            value = randint(1, 100)
-
-            if value < int(self.application.config.IGNORE_PERCENTAGE[project_id]):
-                self.set_header("X-CYCLOPS-STATUS", "IGNORED")
-                self.application.ignored_items += 1
-                self.write("IGNORED")
-                self.finish()
-                return
+        if self.validate_percentage_ignore(project_id):
+            return
 
         # check cache usage
-        count = self.validate_cache(project_id, self.request.body)
-        if count > self.application.config.MAX_CACHE_USES:
+        if self.validate_cache(project_id, self.request.body):
             return
 
         # handle request
+        url = "%s%s?%s" % (self.application.config.SENTRY_BASE_URL, self.request.path, self.request.query)
         self.process_request(project_id, url)
 
     def handle_frontend_get_request(self, project_id):
-        # check project in restrict api list
-        if self.application.config.RESTRICT_API_ACCESS:
-            if int(project_id) not in self.application.project_keys:
-                self._404()
-                return
-
-        # check public key
+        # check project accessibility
         project_id = int(project_id)
-        sentry_key = self.get_argument('sentry_key')
-        if self.application.config.RESTRICT_API_ACCESS:
-            if not sentry_key.strip() in self.application.project_keys[project_id]["public_key"]:
-                self.set_status(403)
-                self.write("INVALID KEY")
-                self.finish()
-                return
-
-        # generate sentry url
-        url = "%s%s?%s" % (self.application.config.SENTRY_BASE_URL, self.request.path, self.request.query)
+        if not self.validate_project_by_public_dsn(project_id):
+            return
 
         # ignore by percentage
-        if project_id in self.application.config.IGNORE_PERCENTAGE:
-            value = randint(1, 100)
-
-            if value < int(self.application.config.IGNORE_PERCENTAGE[project_id]):
-                self.set_header("X-CYCLOPS-STATUS", "IGNORED")
-                self.application.ignored_items += 1
-                self.write("IGNORED")
-                self.finish()
-                return
+        if self.validate_percentage_ignore(project_id):
+            return
 
         # check cache usage
-        count = self.validate_cache(project_id, self.get_argument('sentry_data'))
-        if count > self.application.config.MAX_CACHE_USES:
+        if self.validate_cache(project_id, self.get_argument('sentry_data')):
             return
 
         # handle request
+        url = "%s%s?%s" % (self.application.config.SENTRY_BASE_URL, self.request.path, self.request.query)
         self.process_request(project_id, url)
 
 

--- a/tests/handlers/test_router.py
+++ b/tests/handlers/test_router.py
@@ -244,21 +244,22 @@ class TestGetRouterHandler(BaseRouterTest):
     def test_get_valid_project_with_valid_key(self):
         item = self.app.project_keys.keys()[0]
         key = self.app.project_keys[item]['public_key'][0]
-        response = self.fetch('/api/%s/store/?sentry_key=%s' % (item, key))
+        url = '/api/%s/store/?sentry_key=%s&sentry_data=%s' % (item, key, "%7B%7D")
+        response = self.fetch(url)
 
         self.expect_200(response)
 
         self.expect_correct_response_headers(response, "PROCESSED")
 
         self.expect_one_processed_item(item, "GET",
-                "localhost:9000/api/1/store/?sentry_key=ee0c9d854b294d20a2d6d92d0191cac8")
+                "localhost:9000/api/1/store/?sentry_key=ee0c9d854b294d20a2d6d92d0191cac8&sentry_data=%7B%7D")
 
     def test_get_valid_project_with_valid_key_ignores(self):
         item = self.app.project_keys.keys()[0]
         key = self.app.project_keys[item]['public_key'][0]
 
         for _i in range(self.app.config.MAX_CACHE_USES + 1):
-            response = self.fetch('/api/%s/store/?sentry_key=%s' % (item, key))
+            response = self.fetch('/api/%s/store/?sentry_key=%s&sentry_data=%s' % (item, key, "%7B%7D"))
 
         self.expect_200_ignored(response)
 


### PR DESCRIPTION
Raven prior to v2 (up to 1.3) had the following payload based on GET request:
```
https://cyclops/api/1/store/?sentry_version=7&sentry_client=raven-js/1.3.0&sentry_key=a533644da64e5232377aeb94de0c53eb&sentry_data=%SENTRY_DATA%
```

Where the %SENTRY_DATA% is urlencoded stringified JSON:

```
{
  "project":"1",
  "logger":"my.module",
  "platform":"javascript",
  "request":{
    "headers":{
      "User-Agent":"Mozilla/5.0"
    },
    "url":"http://domain.com/raven.1.3.0.html"
  },
  "exception":{
    "values":[
      {
        "type":"Error",
        "value":"errMsg",
        "stacktrace":{
          "frames":[
            {
              "filename":"http://domain.com/raven.1.3.0.html",
              "lineno":13,
              "colno":25,
              "function":"HTMLButtonElement.onclick",
              "in_app":true
            },
            {
              "filename":"http://domain.com/raven.1.3.0.html",
              "lineno":9,
              "colno":19,
              "function":"f",
              "in_app":true
            }
          ]
        }
      }
    ]
  },
  "culprit":"http://domain.com/raven.1.3.0.html",
  "message":"Error: errMsg",
  "extra":{
    "planet":{
      "name":"Earth"
    },
    "session:duration":5170
  },
  "event_id":"8bba97f719294b01b4eca860b41af197"
}
```

Starting from version 2.0 Raven use POST method instead of GET and POST data to URI in the following format:

```
https://cyclops/api/1/store/?sentry_version=7&sentry_client=raven-js%2F3.17.0&sentry_key=a533644da64e5232377aeb94de0c53eb
```

The body has the same format:

```
{
  "project":"1",
  "logger":"my.module",
  "platform":"javascript",
  "request":{
    "headers":{
      "User-Agent":"Mozilla/5.0"
    },
    "url":"http://domain.com/raven.1.3.0.html"
  },
  "exception":{
    "values":[
      {
        "type":"Error",
        "value":"errMsg",
        "stacktrace":{
          "frames":[
            {
              "filename":"http://domain.com/raven.1.3.0.html",
              "lineno":13,
              "colno":25,
              "function":"HTMLButtonElement.onclick",
              "in_app":true
            },
            {
              "filename":"http://domain.com/raven.1.3.0.html",
              "lineno":9,
              "colno":19,
              "function":"f",
              "in_app":true
            }
          ]
        }
      }
    ]
  },
  "culprit":"http://domain.com/raven.1.3.0.html",
  "extra":{
    "planet":{
      "name":"Earth"
    },
    "session:duration":1521
  },
  "event_id":"3a7f3b10d06a4fa48cd50e899175b886"
}
```

The difference:

GET requests contains sentry_data, POST request doesn't
POST requests contains stringified JSON in body