### PR TITLE
Update derpconf and allow setting configuration through env variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,8 @@ Here is an example configuration file:
 
     ################################################################################
 
+Each setting can also be set/overridden by using environment variables named the same as the configuration setting.
+
 The Routes
 ==========
 

--- a/cyclops/config.py
+++ b/cyclops/config.py
@@ -4,6 +4,7 @@
 from derpconf.config import Config, generate_config
 
 MINUTES = 60
+Config.allow_environment_variables()
 
 Config.define('HEALTHCHECK_TEXT', 'WORKING', 'Cyclops has a /healthcheck route. This allows load balancers to ping it to see if the process is still alive. This option defines the text that the /healthcheck route prints.', 'General')
 Config.define('SENTRY_BASE_URL', 'localhost:9000', 'Sentry server name. This is the base URL that Cyclops will use to send requests to sentry.', 'General')

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ It keeps items in memory and dumps them at sentry in regular intervals.
 
     install_requires=[
         'tornado>=4.3,<4.5',
-        'derpconf==0.3.3',
+        'derpconf==0.8.1',
         'pycurl>=7.19.5.1,<7.20',
         'requests',
         'ujson==1.30',


### PR DESCRIPTION
Support for this was added in derpconf 0.5.1. This is convenient when running
Cyclops inside of Docker where it's common to provide configuration parameters
via environment variables.