### PR TITLE
Make sure the Redis port always is an integer

### DIFF
--- a/cyclops/cache.py
+++ b/cyclops/cache.py
@@ -27,7 +27,7 @@ class RedisCache(Cache):
         if self.application.config.REDIS_HOST is not None:
             self.redis = redis.StrictRedis(
                 host=self.application.config.REDIS_HOST,
-                port=self.application.config.REDIS_PORT,
+                port=int(self.application.config.REDIS_PORT),
                 db=self.application.config.REDIS_DB_COUNT,
                 password=self.application.config.REDIS_PASSWORD
             )

--- a/cyclops/storage.py
+++ b/cyclops/storage.py
@@ -60,7 +60,7 @@ class RedisStorage(object):
 
         self.redis = redis.StrictRedis(
             host=self.application.config.REDIS_HOST,
-            port=self.application.config.REDIS_PORT,
+            port=int(self.application.config.REDIS_PORT),
             db=self.application.config.REDIS_DB_COUNT,
             password=self.application.config.REDIS_PASSWORD
         )


### PR DESCRIPTION
If this isn't done, you might run in to errors such as "TypeError: an integer is required" which isn't very descriptive of where the problem is, in case the port number isn't correctly interpreted as a integer.